### PR TITLE
refactor: improve load_config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,3 @@
-use std::env;
-
-use config::ConfigError;
-
 #[derive(serde::Deserialize)]
 pub struct Config {
     pub database: DatabaseConfig,
@@ -15,43 +11,12 @@ pub struct DatabaseConfig {
 }
 
 pub fn load_config() -> Result<Config, config::ConfigError> {
-    match config::Config::builder()
+    let configuration = config::Config::builder()
         .add_source(config::File::new("config.yaml", config::FileFormat::Yaml))
-        .build()
-    {
-        Ok(config) => config
-            .try_deserialize::<Config>()
-            .or_else(load_config_from_env),
-        Err(e) => load_config_from_env(e),
-    }
-}
+        .add_source(config::Environment::with_prefix("COACH")
+            .prefix_separator("_")
+            .separator("__"))
+        .build()?;
 
-fn load_config_from_env(e: ConfigError) -> Result<Config, config::ConfigError> {
-    log::info!("{}. Loading from environment variables instead.", e);
-
-    let port = env::var("PORT")
-        .unwrap_or_else(|_| "8000".to_string())
-        .parse()
-        .expect("PORT must be a number");
-
-    let results_url = env::var("RESULTS_URL").unwrap_or_else(|_| "".to_string());
-
-    let config: Config = match env::var("DATABASE_URL") {
-        Ok(url) => Config {
-            server_port: port,
-            database: DatabaseConfig { url },
-            results_url,
-        },
-        Err(e) => {
-            log::error!("DATABASE_URL: {}", e);
-            Config {
-                server_port: port,
-                database: DatabaseConfig {
-                    url: String::from(""),
-                },
-                results_url,
-            }
-        }
-    };
-    Ok(config)
+    configuration.try_deserialize::<Config>()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,9 +13,11 @@ pub struct DatabaseConfig {
 pub fn load_config() -> Result<Config, config::ConfigError> {
     let configuration = config::Config::builder()
         .add_source(config::File::new("config.yaml", config::FileFormat::Yaml))
-        .add_source(config::Environment::with_prefix("COACH")
-            .prefix_separator("_")
-            .separator("__"))
+        .add_source(
+            config::Environment::with_prefix("COACH")
+                .prefix_separator("_")
+                .separator("__"),
+        )
         .build()?;
 
     configuration.try_deserialize::<Config>()

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,7 +407,10 @@ async fn main() -> std::io::Result<()> {
         .await
         .expect("Failed to migrate database");
 
-    let app_state = AppState { _config: config, pool };
+    let app_state = AppState {
+        _config: config,
+        pool,
+    };
     let data_app_state = web::Data::new(app_state);
 
     HttpServer::new(move || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ lazy_static! {
 }
 
 struct AppState {
-    config: Config,
+    _config: Config,
     pool: PgPool,
 }
 
@@ -407,7 +407,7 @@ async fn main() -> std::io::Result<()> {
         .await
         .expect("Failed to migrate database");
 
-    let app_state = AppState { config, pool };
+    let app_state = AppState { _config: config, pool };
     let data_app_state = web::Data::new(app_state);
 
     HttpServer::new(move || {


### PR DESCRIPTION
This change keeps the load_config more simple and reusable.
For the Config, the latest resource has priority over others added before. 

To keep parsing possible we need to define some configuration, in this case, we are setting:

```rust
:with_prefix("COACH")
.prefix_separator("_")
.separator("__")
```

If we want to define the database URL I should set the following environment var:
`COACH_DATABASE__URL`

If my struct for some reason needs another level, like:
```rust
#[derive(serde::Deserialize)]
pub struct DatabaseConfig {
    pub url: String,
    pub my_config: MyConfig,
}

#[derive(serde::Deserialize)]
pub struct MyConfig {
    pub name: String,
}
```

We can define the ENV like this: `COACH_DATABASE__MY_CONFIG__NAME`

I have tried to find some way to work without this prefix, but it always fails, I needed to define this prefix to make it work.